### PR TITLE
Closes #13, cacheing now automatic

### DIFF
--- a/frontend/src/Components/Home/Update.elm
+++ b/frontend/src/Components/Home/Update.elm
@@ -37,7 +37,7 @@ update msg model =
                             { homeComponent | dataOne = newDataOne }
                     }
             in
-                ( newModel, LocalStorage.saveModel newModel )
+                ( newModel, Cmd.none )
 
         OnDataTwoChange newDataTwo ->
             let
@@ -50,4 +50,4 @@ update msg model =
                             { homeComponent | dataTwo = newDataTwo }
                     }
             in
-                ( newModel, LocalStorage.saveModel newModel )
+                ( newModel, Cmd.none )

--- a/frontend/src/Components/Init.elm
+++ b/frontend/src/Components/Init.elm
@@ -6,7 +6,7 @@ import Components.Welcome.Init as WelcomeInit
 import Components.Home.Init as HomeInit
 import Components.Messages exposing (Msg(..))
 import Components.Model exposing (Model)
-import Components.Update exposing (update)
+import Components.Update exposing (updateCacheIf)
 import Models.Route as Route
 
 
@@ -32,4 +32,4 @@ init routeResult =
             , welcomeComponent = WelcomeInit.init
             }
     in
-        update LoadModelFromLocalStorage defaultModel
+        updateCacheIf LoadModelFromLocalStorage defaultModel False

--- a/frontend/src/Components/Welcome/Update.elm
+++ b/frontend/src/Components/Welcome/Update.elm
@@ -51,7 +51,7 @@ update msg model =
                             { welcomeComponent | email = newEmail }
                     }
             in
-                ( wipeError newModel, LocalStorage.saveModel newModel )
+                ( wipeError newModel, Cmd.none )
 
         Register ->
             let
@@ -97,12 +97,7 @@ update msg model =
                 newModel =
                     { model | user = Just newUser, route = Route.HomeComponentMain }
             in
-                ( newModel
-                , Cmd.batch
-                    [ LocalStorage.saveModel newModel
-                    , Router.navigateTo newModel.route
-                    ]
-                )
+                ( newModel, Router.navigateTo newModel.route )
 
         Login ->
             let
@@ -118,12 +113,7 @@ update msg model =
                 newModel =
                     { model | user = Just newUser, route = Route.HomeComponentMain }
             in
-                ( newModel
-                , Cmd.batch
-                    [ LocalStorage.saveModel newModel
-                    , Router.navigateTo newModel.route
-                    ]
-                )
+                ( newModel, Router.navigateTo newModel.route )
 
         OnLoginFailure newApiError ->
             let


### PR DESCRIPTION
Originally had `cache`ing be automatic always, but this caused a bug because on the initial page load it would end up `cache`ing the default model and that would override whatever was in there from before. So we have an `updateCacheIf` function now, the default update always `cache`s but if needed you can call update without `cache`ing (as done in the `src/Components/Init.elm`.